### PR TITLE
Tutorial update feb 2017

### DIFF
--- a/_posts/2015-02-09-create-your-application.markdown
+++ b/_posts/2015-02-09-create-your-application.markdown
@@ -110,7 +110,7 @@ For more information about generating a Rails application see the [Getting Start
 
      ```sh
      $ rake solr:clean # Useful when seeing a "core already exists" error.
-     $ rake solr:start # Starts Solr independently of the Rails server in the background
+     $ rake solr:start # Starts Solr independently of the Rails server in the background (without loading core)
      $ rake solr:stop # Stops Solr
      $ rake solr:restart # Stops and restarts an already running background Solr server
      ```

--- a/_posts/2015-02-09-create-your-application.markdown
+++ b/_posts/2015-02-09-create-your-application.markdown
@@ -67,7 +67,6 @@ For more information about generating a Rails application see the [Getting Start
      # In ./Gemfile
      gem 'blacklight'
      gem 'geoblacklight'
-     gem 'jettywrapper'
      ```
 
   1. Install required gems and their dependencies
@@ -81,12 +80,8 @@ For more information about generating a Rails application see the [Getting Start
      ```sh
      $ rails g blacklight:install --devise
      ```
-
-  1. Run GeoBlacklight generator (with a jetty instance for Solr)
-
-     ```sh
-     $ rails g geoblacklight:install --jettywrapper
-     ```
+     Depending on how your machine is setup you may need to prepend the rails or rake command with [bundle exec](http://bundler.io/man/bundle-exec.1.html).
+     {: .flash-alert}
 
   1. Run database migrations
 
@@ -103,44 +98,25 @@ For more information about generating a Rails application see the [Getting Start
      ```
 
 
-  1. Download and install Jetty (Solr server for development, in production you'd have a dedicated Solr instance)
+  1. Start the Solr and Rails server.
 
      ```sh
-     $ rake jetty:download
-     ```
-
-  1. Unzip Jetty
-  
-     ```sh
-     $ rake jetty:unzip
-     ```
-
-  1. Configure Solr to use [GeoBlacklight-Schema](https://github.com/geoblacklight/geoblacklight-schema)
-
-     ```sh
-     $ rake geoblacklight:configure_solr
-     ```
-
-  1. Start the jetty Solr server
-
-     ```sh
-     $ rake jetty:start
+     $ rake geoblacklight:server
      ```
   
-     Running this command will start the jetty [Solr server](http://127.0.0.1:8983/solr) and keep it running until you stop it. Other Jetty commands  available to control Solr include:
+     Running this command will download and start the [Solr server](http://127.0.0.1:8983/solr). Other commands available to control Solr include:
      {: .flash-notice}
 
 
      ```sh
-     $ rake jetty:stop # Stops Jetty
-     $ rake jetty:restart # Restarts Jetty
+     $ rake solr:clean # Useful when seeing a "core already exists" error.
+     $ rake solr:start # Starts Solr independently of the Rails server in the background
+     $ rake solr:stop # Stops Solr
+     $ rake solr:restart # Stops and restarts an already running background Solr server
      ```
 
-  1. Now start your Rails application again and navigate to [http://127.0.0.1:3000](http://127.0.0.1:3000). You should see the GeoBlacklight homepage.
+  1. Navigate to [http://127.0.0.1:3000](http://127.0.0.1:3000). You should see the GeoBlacklight homepage. CTRL + c will stop both the Solr and Rails server.
 
-     ```sh
-     $ rails s -b 0.0.0.0
-     ```
 
   1. *Optional* Commit your work
 

--- a/_posts/2015-02-09-create-your-application.markdown
+++ b/_posts/2015-02-09-create-your-application.markdown
@@ -80,6 +80,13 @@ For more information about generating a Rails application see the [Getting Start
      ```sh
      $ rails g blacklight:install --devise
      ```
+
+  1. Run GeoBlacklight generator (overrides Blacklight default Solr config)
+
+     ```sh
+     $ rails g geoblacklight:install -f
+     ```
+
      Depending on how your machine is setup you may need to prepend the rails or rake command with [bundle exec](http://bundler.io/man/bundle-exec.1.html).
      {: .flash-alert}
 

--- a/_posts/2015-02-09-customize-your-application.markdown
+++ b/_posts/2015-02-09-customize-your-application.markdown
@@ -38,11 +38,10 @@ When it comes to customizing your GeoBlacklight application there are some basic
 
 In this example we are going to change the way the GeoBlacklight is configured to show certain metadata fields on an items page. This is the same way a Blacklight application would configure these fields.
 
-  1. Make sure your Jetty server and Rails application are started.
+  1. Make sure your Solr server and Rails application are started.
 
      ```sh
-     $ rake jetty:start
-     $ rails s -b 0.0.0.0
+     $ rake geoblacklight:server
      ```
 
   1. Open the `catalog_controller.rb` file in your text editor.
@@ -51,37 +50,37 @@ In this example we are going to change the way the GeoBlacklight is configured t
      Hint: `catalog_controller.rb` is located at "app/controllers/catalog_controller.rb" in your application
      {: .flash-notice}
 
-  1. Scroll down to lines 119 - 126.
+  1. Scroll down to lines 121 - 128.
 
      ```ruby
      ...
-     config.add_show_field 'dc_creator_sm', label: 'Author(s)', itemprop: 'author'
-     config.add_show_field 'dc_description_s', label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
-     config.add_show_field 'dc_publisher_s', label: 'Publisher', itemprop: 'publisher'
-     config.add_show_field 'dct_isPartOf_sm', label: 'Collection', itemprop: 'isPartOf'
-     config.add_show_field 'dct_spatial_sm', label: 'Place(s)', itemprop: 'spatial', link_to_search: true
-     config.add_show_field 'dc_subject_sm', label: 'Subject(s)', itemprop: 'keywords', link_to_search: true
-     config.add_show_field 'dct_temporal_sm', label: 'Year', itemprop: 'temporal'
-     config.add_show_field 'dct_provenance_s', label: 'Held by', link_to_search: true
+     config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author'
+     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
+     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
+     config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
+     config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_search: true
+     config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_search: true
+     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
+     config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_search: true
      ...
      ```
      These configuration options relate to fields that are indexed in Solr. You can disable a metadata field being shown on an items show page. If you navigate to an [items page](http://127.0.0.1:3000/catalog/stanford-cg357zz0321), it will currently show field called publisher. Maybe you would like to rename that field to "Data publisher".
 
-  1. Modify the label in line 121
+  1. Modify the label in line 123
 
      ```ruby
      # change this
-     config.add_show_field 'dc_publisher_s', label: 'Publisher', itemprop: 'publisher'
+     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
      # to this
-     config.add_show_field 'dc_publisher_s', label: 'Data publisher', itemprop: 'publisher'
+     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Data publisher', itemprop: 'publisher'
      ```
 
      Save the file and reload the page. You should see the label change.
 
-  1. Next we will remove the "Author(s)" metadata field from being shown. Comment out or remove the `dc_creator_sm` line (119).
+  1. Next we will remove the "Author(s)" metadata field from being shown. Comment out or remove the `Settings.FIELDS.CREATOR` line (121).
 
      ```ruby
-     # config.add_show_field 'dc_creator_sm', label: 'Author(s)', itemprop: 'author'
+     # config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author'
      ```
      Save the file and reload the page. You should no longer see the "Author(s)" field.
     
@@ -110,7 +109,6 @@ GeoBlacklight uses [Twitter Bootstrap](http://getbootstrap.com/) as a base for U
      ```scss
      // in app/assets/stylesheets/geoblacklight.scss
      @import 'geoblacklight/application';
-     @import 'blacklight_range_limit';
      ```
 
   1. Create file `app/assets/stylesheets/bootstrap-variables.scss` and import it from `blacklight.scss`

--- a/_posts/2015-02-09-index-solr-documents.markdown
+++ b/_posts/2015-02-09-index-solr-documents.markdown
@@ -41,6 +41,12 @@ GeoBlacklight provides a rake task to index documents as fixtures for tests. We 
      $ cd - # Or cd ../../../
      ```
 
+  1. Make sure your Solr server and Rails application are started.
+
+     ```sh
+     $ rake geoblacklight:server
+     ```
+
 ### Index fixture metadata documents
 
   1. Run the GeoBlacklight fixture indexer
@@ -50,12 +56,6 @@ GeoBlacklight provides a rake task to index documents as fixtures for tests. We 
      ```
     
 The GeoBlacklight Solr seed task, indexes metadata documents (in JSON format) stored in the `spec/fixtures/solr_documents` directory.
-
-  1. Start the Rails server again
-
-     ```sh
-     $ rails s -b 0.0.0.0
-     ```
 
   1. *Optional* Commit your work
 

--- a/_posts/2015-02-09-setting-up-your-environment.markdown
+++ b/_posts/2015-02-09-setting-up-your-environment.markdown
@@ -14,14 +14,14 @@ snippet: 'Setting up your development environment for GeoBlacklight. Created as 
 
 ### Development requirements
 
-GeoBlacklight has similar prerequisites to [Blacklight][blacklight]. It diverges from Blacklight requirements by using a customized Solr schema and configuration, [Geoblacklight-Schema][geoblacklightschema].
+GeoBlacklight has similar prerequisites to [Blacklight][bldependencies]. It diverges from Blacklight requirements by using a customized Solr schema and configuration, [Geoblacklight-Schema][geoblacklightschema].
 
 #### Software you should have installed on your development computer
 
   - [Ruby > 1.9.3][installruby]
   - [Rails > 4][installrails]
   - [Git][installgit]
-  - Java (for local Solr server)
+  - [Java > 1.8][installjava] (Download JDK for local Solr server)
 
 Local attendees of the workshop have the option of just using the pre-created environment on the provided thumb-drive. If you are not at the workshop, you can create the virtual machine for the workshop, by following [this guide]({% post_url 2016-01-23-using-packer-to-create-a-development-virtual-machine %}).
 
@@ -108,5 +108,6 @@ Note: Please install a Windows ssh client installed such as [ PuTTY](http://www.
 [installruby]:          https://gorails.com/setup#ruby
 [installrails]:         https://gorails.com/setup#rails
 [installgit]:           https://gorails.com/setup#git
+[installjava]:          http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [rubyonrails]:          http://rubyonrails.org/
-[blacklight]:           http://projectblacklight.org/
+[bldependencies]:           https://github.com/projectblacklight/blacklight/wiki/Quickstart


### PR DESCRIPTION
Updates the tutorial based on roadblocks encountered during [geo4libcamp 2017](https://docs.google.com/document/d/17-MYJcC8ArNB9_tO0w5HKTm6PfJokXgqXkfwh_Cnwqs/edit?usp=sharing) geoblacklight workshop session.
 - Replaces jetty_wrapper with solr_wrapper
 - Adds java and Blacklight dependency links
 - Update customizations page to reflect updated application_controller and no longer included range limit plugin.

The Geoblacklight schema was updated since the last time the tutorial was updated. Rather than changing the url to download the sample geoblacklight-documents @mejackreed can you update your [gist](https://gist.github.com/mejackreed/84abc598927c43af665b) with my [fork](https://gist.github.com/tampakis/5009e31672ae090270086405dfa6b674) which removes the unsupported fields?