### PR TITLE
Use https://geoblacklight.org as Jekyll baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ email: geoblacklight-working-group@googlegroups.com
 description: > # this means to ignore newlines until "baseurl:"
   An easier way to find geospatial data
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://geoblacklight.org" # the base hostname & protocol for your site
+url: "https://geoblacklight.org" # the base hostname & protocol for your site
 twitter_username: geoblacklight
 github_username:  geoblacklight
 collections:


### PR DESCRIPTION
Jekyll has been generating links throughout the GeoBlacklight site as `http://geoblacklight.org`, which is set as the baseurl for the site. This leads to notifications from Netlify on every deploy that the site has mixed content, which it doesn't because it has HTTPS enabled on Netlify.

This pull request modifies a Jekyll configuration option to treat `https://geoblacklight.org` as the baseurl for everything, which will suppress these build messages from Netlify.