### PR TITLE
Added community sprint page, updated categories for posts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,8 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.3)
     multipart-post (2.1.1)
+    nokogiri (1.11.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -254,6 +256,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -261,4 +264,4 @@ DEPENDENCIES
   jekyll
 
 BUNDLED WITH
-   2.2.5
+   2.2.26

--- a/_posts/2017-08-24--summer-code-sprint-version1.6.0-released.md
+++ b/_posts/2017-08-24--summer-code-sprint-version1.6.0-released.md
@@ -2,7 +2,7 @@
 layout: post
 title: Summer Code Sprint concludes and GeoBlacklight version 1.6.0 released
 date: 2017-08-25
-categories: blog
+categories: blog | sprint
 author:
 - Karen Majewicz
 - Andrew Battista
@@ -15,7 +15,7 @@ Developers and metadata specialists from New York University, Princeton Universi
 
 ### Changes and Implementations
 
-The code sprint and release of version 1.6.0 resulted in a significant new feature, an amazing [tabbed viewer](https://github.com/geoblacklight/geoblacklight/pull/555) that displays standards based XML metadata as HTML in the interface. This was primarily developed by James Griffin, and represents an enhancement that has long been requested by many GeoBlacklight users. Now, users can see a cleaner rendering of ISO or FGDC XML documents in context and download them. 
+The code sprint and release of version 1.6.0 resulted in a significant new feature, an amazing [tabbed viewer](https://github.com/geoblacklight/geoblacklight/pull/555) that displays standards based XML metadata as HTML in the interface. This was primarily developed by James Griffin, and represents an enhancement that has long been requested by many GeoBlacklight users. Now, users can see a cleaner rendering of ISO or FGDC XML documents in context and download them.
 
 ![ISO19139](/images/geoblacklight_metadata_view_ISO19139.png)
 
@@ -28,4 +28,3 @@ Exploration of a larger development was initiated during the sprint, which led t
 For now, the team has created a development branch of GeoBlacklight for the new schema that includes example [fixture documents](https://github.com/geoblacklight/geoblacklight/tree/json-ld-schema/spec/fixtures/jsonld) of DCAT-compliant records. There are implications for moving toward the DCAT standard, the most significant of which is the need to "flatten" fully realized .JSON-LD metadata into .JSON files that comply with the Solr cores behind GeoBlacklight. [GeoCompile](https://github.com/geoblacklight/geo_compile), developed by Eliot and Stephen, is an initial step at making sure this happens seamlessly. Major thanks to Karen Majewicz, Andrew Battista, Stephen Balogh, and Eliot Jordan for doing some thinking and mocking-up during the sprint.
 
 These projects are still in progress and will be completed in the coming months. When we finish mocking up the proposed changes, which are gestured in the fixture record, we will follow up with a more complete post that explains the rationale for choices made and solicits further feedback from the community before any adoptions take place. Thanks to everyone who contributed to the sprint. In the meantime, we welcome comments and questions; [follow or contribute to the GeoBlacklight development work on GitHub!](https://github.com/geoblacklight/geoblacklight)
-

--- a/_posts/2018-03-01--winter-code-sprint-version1.8.md
+++ b/_posts/2018-03-01--winter-code-sprint-version1.8.md
@@ -2,7 +2,7 @@
 layout: post
 title: GeoBlacklight Winter Code Sprint 2018 & New Release 1.8
 date: 2018-03-01
-categories: blog
+categories: blog | sprint
 author: Karen Majewicz
 snippet: 'The GeoBlacklight Community Winter Code Sprint has resulted in a new release (1.8.0) that includes a new feature for index maps, bug fixes, and improved metadata documentation.'
 ---
@@ -14,5 +14,3 @@ Developers from Stanford, Princeton, NYU, Cornell, and the University of Minneso
 
 #### [Check out this index map in EarthWorks from Stanford Libraries:](https://earthworks.stanford.edu/catalog/stanford-ts545zc6250)
 [![indexMap](/images/indexMap.png)](https://earthworks.stanford.edu/catalog/stanford-ts545zc6250)
-
-

--- a/_posts/2018-08-10-summer-code-sprint-version-1_9.md
+++ b/_posts/2018-08-10-summer-code-sprint-version-1_9.md
@@ -2,7 +2,7 @@
 layout: post
 title: GeoBlacklight 2018 Summer Sprint Wrap-up
 date: 2018-08-10 12:00:00
-categories: blog
+categories: blog | sprint
 author:
 - Karen Majewicz
 - Andrew Battista

--- a/_posts/2019-02-01-winter-code-sprint-version-2.md
+++ b/_posts/2019-02-01-winter-code-sprint-version-2.md
@@ -2,7 +2,7 @@
 layout: post
 title: GeoBlacklight 2.0 is Here!
 date: 2019-02-01 12:00:00
-categories: blog
+categories: blog | sprint
 author: Karen Majewicz
 snippet: 'The GeoBlacklight Community Winter Codesprint results in Version 2.0'
 ---

--- a/_posts/2020-09-15-summer-sprint-2020.md
+++ b/_posts/2020-09-15-summer-sprint-2020.md
@@ -2,14 +2,14 @@
 layout: post
 title: GeoBlacklight 3.0 is Here!
 date: 2020-09-15 12:00:00
-categories: blog
+categories: blog | sprint
 author: Karen Majewicz
 snippet: 'The GeoBlacklight Summer Community Sprint Activities'
 ---
 
 ## 2020 Summer Community Sprint
 
-Our [Summer Community Sprint](https://github.com/geoblacklight/geoblacklight/projects/8) concluded in August 2020 and resulted in a [new version of GeoBlacklight](https://github.com/geoblacklight/geoblacklight/releases)! Version 3 brings us the long awaited multiple downloads option, support for Rails 6, and many improvements for accessibility. 
+Our [Summer Community Sprint](https://github.com/geoblacklight/geoblacklight/projects/8) concluded in August 2020 and resulted in a [new version of GeoBlacklight](https://github.com/geoblacklight/geoblacklight/releases)! Version 3 brings us the long awaited multiple downloads option, support for Rails 6, and many improvements for accessibility.
 
 ### Notable Activities and Enhancements
 
@@ -17,7 +17,7 @@ Our [Summer Community Sprint](https://github.com/geoblacklight/geoblacklight/pro
 
 * NEW NAME FOR THE DEFAULT BRANCH: We changed the name of the default branch to “Main.” There is a growing consensus in the development world for projects to change the default branch of their code in GitHub away from "master," as this is a loaded, potentially offensive, term. Read more about it here, including comments from our community: [https://github.com/geoblacklight/geoblacklight/issues/940](https://github.com/geoblacklight/geoblacklight/issues/940)
 
-* ICONS: We deprecated the geoblacklight-icons project, which relied upon font-awesome for the icons. Now, new SVG images can be submitted directly to the GeoBlacklight repository  or added in your own GeoBlacklight application. 
+* ICONS: We deprecated the geoblacklight-icons project, which relied upon font-awesome for the icons. Now, new SVG images can be submitted directly to the GeoBlacklight repository  or added in your own GeoBlacklight application.
 
 * METADATA SCHEMA WORKGROUP: During the sprint, we convened a Metadata Schema Workgroup to assess the current GeoBlacklight Schema 1.0 and develop an upgraded version. The workgroup will continue to meet throughout 2020.
 

--- a/_posts/2021-02-10-announcing-winter-sprint-2021.md
+++ b/_posts/2021-02-10-announcing-winter-sprint-2021.md
@@ -2,7 +2,7 @@
 layout: post
 title: Announcing the GeoBlacklight Community Winter 2021 Sprint
 date: 2021-02-10 12:00:00
-categories: blog
+categories: blog | sprint
 author: Karen Majewicz
 snippet: 'Join us for the next GeoBlacklight Community Winter Sprint!'
 ---

--- a/about.md
+++ b/about.md
@@ -39,7 +39,7 @@ Visit the [Connect](https://geoblacklight.org/connect.html) page to join our onl
 
 - **Every month:** [Zoom meetings](https://z.umn.edu/gbl-meetings) to share project updates and to discuss topical issues.
 
-- **2x per year:** [Community Sprints](https://github.com/geoblacklight/geoblacklight/projects?query=). These are similar to a traditional code sprint but also incorporate activities around documentation, metadata, governance, and more.
+- **2x per year:** [Community Sprints](/communitysprint.html) are similar to a traditional code sprint but also incorporate activities around documentation, metadata, governance, and more.
 
 - **Annually:** [Geo4LibCamp](https://geo4libcamp.org/) is a hands-on meeting to bring together those building repository services for geospatial data. The main focus is to share best-practices, solve common problems, and address technical issues with integrating geospatial data into a repository and associated services.
 

--- a/communitysprint.html
+++ b/communitysprint.html
@@ -1,0 +1,38 @@
+---
+layout: default
+title: 'GeoBlacklight Community Sprints'
+---
+<div>
+  <h1>Geoblacklight Commmunity Sprints
+  </h1>
+  <br>
+  <p>
+  The GeoBlacklight Community collaborates on a 2-week sprint every Winter and Summer. Participation in the sprint is open to anyone interested in working on GeoBlacklight. While similar to a traditional code sprint, the GeoBlacklight Community Sprints also include tackling issues around documentation, metadata, community governance, and more.
+  </p>
+  <p>
+    Each sprint starts with a kickoff meeting where we review our goals and volunteer to contribute towards various issues. This is then followed by short standup meetings every day to check-in and plan our next activities. The exact dates of a sprint are determined the season prior to the sprint. If you are interested in participating, visit the <a href="/connect.html">Connect page</a> to join our community.
+  </p>
+</div>
+<div class='posts'>
+  <hr>
+  <br>
+  <h3>Prior Sprints</h3>
+  <br>
+  <ul class='unstyled'>
+    {% for post in site.categories.sprint %}
+      <li>
+        <h4>
+          <a class="" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        </h4>
+        <p class='post-snippet'>{{ post.snippet }}</p>
+        <p class='post-metadata'>
+          {% if post.author %}
+              {{ post.author | join: ' and ' }}
+          {% endif %} – <span class='post-date'>{{ post.date | date: "%B %-d, %Y" }}</span>
+        </p>
+      </li>
+      <hr>
+    {% endfor %}
+  </ul>
+
+</div>


### PR DESCRIPTION
Created a community page and a new category for posts ('sprint'). Updated posts on sprints with this new category so that these posts appear in both "Blog" and the Community Sprint page. 