### PR TITLE
Quick start steps should use latest stable release

### DIFF
--- a/docs/docs/geoblacklight_quick_start.md
+++ b/docs/docs/geoblacklight_quick_start.md
@@ -10,7 +10,7 @@ This guide covers the quickest way to get up and running with GeoBlacklight, inc
   Bootstrap a new GeoBlacklight Ruby on Rails application using the template script:
 
 ```bash
-DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/main/template.rb
+DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.0/template.rb
 ```
   Then run the `geoblacklight:server` rake task to run the application:
 


### PR DESCRIPTION
## Problem

Following the quick start instructions currently results in a potentially unusable application.

For example, I tried just now to spin up a GeoBlacklight instance and the homepage failed with: `Error: Undefined variable: "$text-muted".`

## Solution

Change the quick start instructions to point to the latest stable release's template

## Notes

This will require upkeep when there's a new release, but I believe it's a better experience to start with a stable release rather than something that's in flux.

I'd totally understand if the preference is to fail forward and just make sure `main` is always generating a working project. I wonder if that's something that could be automated in CI...