### PR TITLE
Update quick start to point to 4.4.1 release

### DIFF
--- a/docs/docs/geoblacklight_quick_start.md
+++ b/docs/docs/geoblacklight_quick_start.md
@@ -10,7 +10,7 @@ This guide covers the quickest way to get up and running with GeoBlacklight, inc
   Bootstrap a new GeoBlacklight Ruby on Rails application using the template script:
 
 ```bash
-DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.0/template.rb
+DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.1/template.rb
 ```
   Then run the `geoblacklight:server` rake task to run the application:
 


### PR DESCRIPTION
GeoBlacklight 4.4.1 was recently released so the Quick Start document should now point to 4.4.1.