### PR TITLE
Update quick start instructions to use 4.4.2

### DIFF
--- a/docs/docs/geoblacklight_quick_start.md
+++ b/docs/docs/geoblacklight_quick_start.md
@@ -10,7 +10,7 @@ This guide covers the quickest way to get up and running with GeoBlacklight, inc
   Bootstrap a new GeoBlacklight Ruby on Rails application using the template script:
 
 ```bash
-DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.1/template.rb
+DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.2/template.rb
 ```
   Then run the `geoblacklight:server` rake task to run the application:
 


### PR DESCRIPTION
Making sure the quick start instructions point to the latest stable 4.X tag