### PR TITLE
v5 quickstart docs

### DIFF
--- a/docs/docs/developers.md
+++ b/docs/docs/developers.md
@@ -14,8 +14,8 @@ This page is for software developers looking to build GeoBlacklight from source,
 You should have the following installed before beginning:
 
 <ul>
-    <li>Ruby > 3.0.0</li>
-    <li>Java > JRE version 11 or higher</li>
+    <li>Ruby (check the minimum required version on <a href="https://rubygems.org/gems/geoblacklight">GeoBlacklight's rubygems page</a>)</li>
+    <li><a href="https://docs.docker.com/get-started/get-docker/">Docker Desktop</a> for your operating system</li>
 </ul>
 ---------
 

--- a/docs/docs/geoblacklight_quick_start.md
+++ b/docs/docs/geoblacklight_quick_start.md
@@ -1,31 +1,47 @@
 # GeoBlacklight Quick Start
+
 This guide covers the quickest way to get up and running with GeoBlacklight, including:
 
- - How to install GeoBlacklight on your local computer.
- - How to create a new application.
- - How to add and index geospatial content.   
+- How to create a new application.
+- How to add and index geospatial content.
 
-## Installation
+!!! warning "Required dependencies"
+    Before getting started, make sure you have installed the [required dependencies listed on the Developers page](../developers#dependencies). You will also need the Ruby on Rails CLI installed for the `rails new` command:
+    
+    ```bash
+    gem install rails
+    ```
 
-  Bootstrap a new GeoBlacklight Ruby on Rails application using the template script:
+## Creating a new GeoBlacklight application
+
+Bootstrap a new GeoBlacklight application using the template script, replacing `app-name` with the name of your new application:
 
 ```bash
-DISABLE_SPRING=1 rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/v4.4.1/template.rb
+rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/main/template.rb -a propshaft --css bootstrap --js rollup
 ```
-  Then run the `geoblacklight:server` rake task to run the application:
+
+Then run the `geoblacklight:server` rake task to run the application:
 
 ```bash
-$ cd app-name
-$ bundle exec rake geoblacklight:server
+cd app-name # replace with your app's name
+bundle exec rake geoblacklight:server
 ```
 
-* Visit your GeoBlacklight application at: [http://localhost:3000](http://localhost:3000)
-* Visit the Solr admin panel at: [http://localhost:8983/solr/#/blacklight-core](http://localhost:8983/solr/#/blacklight-core)
+- Visit your GeoBlacklight application at: [http://localhost:3000](http://localhost:3000)
+- Visit the Solr admin panel at: [http://localhost:8983/solr/#/blacklight-core](http://localhost:8983/solr/#/blacklight-core)
+
+!!! info "Using importmaps for JavaScript"
+
+    The default GeoBlacklight template uses [Vite](https://vite-ruby.netlify.app/guide/rails.html) to bundle the application's JavaScript. If you would prefer to use Rails's default of [importmaps](https://github.com/rails/importmap-rails), you can set `--js importmap` when generating your application:
+
+    ```bash
+    rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/main/template.rb -a propshaft --css bootstrap --js importmap
+    ```
 
 ## Index Example Data
 
 With your Solr server and Rails server already running (via the `geoblacklight:server` rake task above), open a new terminal window and index the GeoBlacklight project's test fixtures via:
 
 ```bash
-$ bundle exec rake "geoblacklight:index:seed[:remote]"
+bundle exec rake "geoblacklight:index:seed[:remote]"
 ```


### PR DESCRIPTION
This updates the quickstart docs to supply the correct options
for generating a geoblacklight v5 app and adds some additional
info about using importmaps, if desired.

Also adds docker to the list of requirements, since it's used
for the default development stack now.

Ref https://github.com/geoblacklight/geoblacklight/issues/1646
