### PR TITLE
Fix typos in GBL website

### DIFF
--- a/docs/blog/posts/2015-02-09-a-hands-on-introduction-to-geoblacklight.markdown
+++ b/docs/blog/posts/2015-02-09-a-hands-on-introduction-to-geoblacklight.markdown
@@ -444,7 +444,7 @@ The fixtures directory is useful for quickly indexing a small number documents i
 Now you should see <a href="http://127.0.0.1:3000">facets listed</a> on the lower left hand part of the page. Try a search! You can <a href="http://127.0.0.1:3000/?q=*">search for *</a> to search for everything.
 
 
-Want to index some more documents? Check out [this tutorial](2015-02-05-using-geocombine-to-harvest-and-index-opengeometadata.md) on how to easily index metadata from OpenGeoMetadata.
+Want to index some more documents? Check out [this tutorial](2015-02-05-using-geocombine-to-harvest-and-index-opengeometadata.markdown) on how to easily index metadata from OpenGeoMetadata.
 
 There are many ways to customize your GeoBlacklight application, and unfortunately we can't cover them all with this tutorial. GeoBlacklight tries to stick to similar patterns as Blacklight, so most of the Blacklight customization techniques should hold true.
 

--- a/docs/docs/metadata-functions.csv
+++ b/docs/docs/metadata-functions.csv
@@ -1,6 +1,6 @@
 Label</br>Field URI,Required - will cause app to error if missing,Default facet,Search results display,Item show default display,Relation widget,Notes
 **ID**</br>id,==yes==,no,no,no,no,Functions as the slug (end part) of the item's URL
-**Access Rights**</br>dct_accessRights_s,==yes==,no,icon,no,no,"If set to ""Restricted"", a closed padlock icon appears next to the title. Downloads and web service previews will be hidden unless a user logs in using an authentication process. If set to ""Public"", an open padlock icon appears next to the title. Downloads and web services are accessible."
+**Access Rights**</br>dct_accessRights_s,==yes==,==yes==,icon,no,no,"If set to ""Restricted"", a closed padlock icon appears next to the title. Downloads and web service previews will be hidden unless a user logs in using an authentication process. If set to ""Public"", an open padlock icon appears next to the title. Downloads and web services are accessible."
 **Format**</br>dct_format_s,{++conditional++},==yes==,no,==yes==,no,Required if a Download link is included. This value displays on the item show in the button under the download widget.
 **Title**</br>dct_title_s,no (see notes),no,Clickable text,==yes==,no,"If a title is missing, GeoBlacklight will display the ID as the title."
 **Alternative Title**</br>dct_alternative_sm,no,no,no,==yes==,no,-
@@ -39,5 +39,5 @@ Label</br>Field URI,Required - will cause app to error if missing,Default facet,
 **Suppressed**</br>gbl_suppressed_b,no,no,no,no,no,Hides items from search results. Items are only visible as  child or related records in the Relations widgets.
 **Temporal Coverage**</br>dct_temporal_sm,no,no,no,==yes==,no,-
 **Theme**</br>dcat_theme_sm,no,==yes==,no,==yes==,no,-
-**WxS Identifier**</br>gbl_wxsIdentifier_s,no,no,no,no,no,Required if a OCG web service is included
+**WxS Identifier**</br>gbl_wxsIdentifier_s,{++conditional++},no,no,no,no,Required if a OCG web service is included
 **Modified**</br>gbl_mdModified_dt,no,no,no,no,no,-

--- a/docs/docs/metadata.md
+++ b/docs/docs/metadata.md
@@ -23,7 +23,6 @@ Metadata schema features:
 
 ## Metadata functionality in GeoBlacklight 4.x
 
-!!! inline Tip "Hover over the column headers for sorting options."
-	
+!!! Tip "Hover over the column headers for sorting options."
 
 {{ read_csv('docs/docs/metadata-functions.csv') }}


### PR DESCRIPTION
* Fixes a broken link on the [2/9/15 blog post](https://geoblacklight.org/blog/2015/02/a-hands-on-introduction-to-geoblacklight---geoblacklight-workshop/#:~:text=Want%20to%20index%20some%20more%20documents%3F%20Check%20out%20this%20tutorial%20on%20how%20to%20easily%20index%20metadata%20from%20OpenGeoMetadata.) (note: both this and the referenced file end in `.markdown` instead of `.md`. I tried changing those file extensions, but doing so updates the 'last edited' date and I didn't want to mess with that)
* Fixes two typos in the [Metadata functionality in GeoBlacklight 4.x table](https://geoblacklight.org/docs/metadata/#metadata-functionality-in-geoblacklight-4x)
  * Access Rights --> default facet
  * WxS Identifier --> conditionally required
* Reformats the tip box to float above the table instead of inline, making the table easier to read (IMO)