### PR TITLE
Update footer links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,9 +82,9 @@ extra:
           - icon: fontawesome/brands/github 
             link: https://github.com/GeoBlacklight
           - icon: fontawesome/brands/slack
-            link: https://geoblacklight.slack.com
+            link: https://geo4lib.slack.com
           - icon: fontawesome/solid/paper-plane
-            link: https://groups.google.com/g/geoblacklight-working-group
+            link: https://groups.google.com/g/geo4lib-community
 
 nav:
 - Home: 'index.md'


### PR DESCRIPTION
Updates Slack and Google Group links in footer to the new Geo4Lib URLs. 

closes https://github.com/geoblacklight/geoblacklight.github.io/issues/281