### PR TITLE
Add more git metadata to CI workflow for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # needed for correct revision dates in commits
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
           cache: pip
       - run: pip install -r requirements.txt
+      - run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: mike deploy --push latest


### PR DESCRIPTION
The build was erroring because it didn't have enough history to
be able to complete the build process. This change fetches the
entire git history, and also sets a default user/email to tie
the commit to, so that mike doesn't complain.
